### PR TITLE
docs: add README and CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+We welcome contributions to the Charmhub listing review process!
+
+Before working on changes, please consider [opening an issue](https://github.com/canonical/charmhub-listing-review/issues) explaining your use case. If you would like to chat with us about your use cases or proposed implementation, you can reach us at [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com) or [Discourse](https://discourse.charmhub.io/).
+
+# Recommendations for process changes
+
+## Best practices
+
+If you've identified a charming best practice that is not currently found, or that needs adjusting, in the [Ops](https://ops.readthedocs.io) ([repo](https://github.com/canonical/operator)), [Juju](https://juju.is/docs) ([repo](https://github.com/juju/juju)), or [Charmcraft](https://canonical-charmcraft.readthedocs-hosted.com/latest/) ([repo](https://github.com/canonical/charmcraft)) documentation, please suggest it by opening a documentation pull request in those repositories.
+
+Best practice notes should be added to the doc where charmers are most likely to discover them. For charmcraft, this tends to be the [`charmcraft.yaml` reference](https://canonical-charmcraft.readthedocs-hosted.com/latest/reference/files/charmcraft-yaml-file/), and for Ops, this tends to be the [relevant how-to guide](https://ops.readthedocs.io/en/latest/howto/index.html).
+
+In a Markdown (.md) document, the note should be added using a triple-backtick admonition block. For example:
+
+````markdown
+
+```{admonition} Best practice
+:class: hint
+
+Capture output to `stdout` and `stderr` in your charm and use the logging and
+warning functionality to send messages to the charm user, rather than rely on
+Juju capturing output.
+```
+
+````
+
+In a reStructuredText (.rst) document, the note should be added with an admonition block. For example:
+
+```rst
+.. admonition:: Best practice
+    :class: hint
+
+    Prefer lowercase alphanumeric names, and use hyphens (-) to separate words. For
+    charms that have already standardised on underscores, it is not necessary to
+    change them, and it is better to be consistent within a charm then to have
+    some action names be dashed and some be underscored.
+```
+
+The text in the block should be concise and suitable to be collated in a list of best practices (without the surrounding context). Place the block at an appropriate point in the document, avoiding multiple blocks (including notes, tips, cautions, and other admonitions) in a row.
+
+## Other listing requirements
+
+To propose adding, changing, or removing a requirement for public listing on Charmhub, open a pull request in this repository.
+
+If more information will be required to evaluate the requirement, add a new field to [the issue template](./.github/ISSUE_TEMPLATE/listing-request.yaml). Where possible, the evaluation should use the information on the Charmhub page or in the source repository, to minimise the number of fields required when requesting a review.
+
+If the requirement can be automatically evaluated, add an evaluation method to [the evaluation script](./evaluate.py). We do not use AI/LLM tools for evaluation at this time.
+
+If the requirement cannot be automatically evaluated, add it to the [issue script](./update_issue.py) in the issue description template.
+
+# Pull requests
+
+Changes are proposed as [pull requests on GitHub](https://github.com/canonical/charmhub-listing-review/pulls).
+
+Pull requests should have a short title that follows the [conventional commit style](https://www.conventionalcommits.org/en/) using one of these types:
+
+- chore
+- ci
+- docs
+- feat
+- fix
+- perf
+- refactor
+- revert
+- test
+
+Some examples:
+
+- feat: automate subprocess best practice check
+- fix!: correct the validation of unit tests passing
+- docs: clarify the instructions for proposing a new best practice
+- ci: adjust the workflow that annotates listing requests
+
+We consider this project too small to use scopes, so we don't use them.
+
+Note that the commit messages to the PR's branch do not need to follow the conventional commit format, as these will be squashed into a single commit to `main` using the PR title as the commit message.
+
+To help us review your changes, please rebase your pull request onto the `main` branch before you request a review. If you need to bring in the latest changes from `main` after the review has started, please use a merge commit.
+
+# Coding style
+
+We have a team [Python style guide](https://github.com/canonical/operator/blob/main/STYLE.md), most of which is enforced by CI checks.
+
+# Copyright
+
+The format for copyright notices is documented in the [LICENSE.txt](LICENSE.txt). New files should begin with a copyright line with the current year (e.g. Copyright 2025 Canonical Ltd.) and include the full boilerplate (see APPENDIX of [LICENSE.txt](LICENSE.txt)). The copyright information in existing files does not need to be updated when those files are modified -- only the initial creation year is required.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# charmhub-listing-review
-Requests for public listing on charmhub.io and automation of that process
+# Requests for public listing on charmhub.io
+
+Charms on [Charmhub](https://charmhub.io) are either privately listed, meaning
+that they can be deployed and their page viewed only if you know the name of the
+charm, or publicly listed, meaning that they can be found when searching (either
+on Charmhub itself or a more general web search leading to Charmhub).
+
+Anyone can publish a charm to Charmhub, and when first published it will be
+privately listed. To change the charm to be publicly listed requires passing a
+lightweight review process to ensure charm consistency and quality. This is a
+one-off process (in most circumstances), not done for each revision of a charm.
+
+Reviewing charms encourages the involvement of the community. The community
+refers to individuals and organisations creating or contributing to charms,
+Juju, and the wider charming ecosystem. The goals of the review are:
+
+1. Be transparent about the capabilities and qualities of a charm.
+2. Ensure a common level of quality.
+
+A listing review is *not* code review. The reviewer may be looking at some of
+the charm code, and may have comments on it, but the listing review is not a
+review of the architecture or design of the charm, and is not a line-by-line
+review of the charm code.
+
+This repository contains:
+
+* Issues that are requests for changing a charm to be publicly listed.
+* Infrastructure to support the review process (such as automatically assigning
+  reviews, tools to check some criteria automatically, and so on).
+
+## Steps of a review
+
+1. The author requests a review for *one* charm at a time with all prerequisites
+   using a [listing request issue](https://github.com/canonical/charmhub-listing-review/issues/new)
+   in this repository.
+2. The reviewer checks if the prerequisites are met and the pull request is
+   ready.
+3. The public review is carried out as a conversation on the pull request.
+4. The review concludes if the charm is 'publication ready', and if so the store
+   team is asked to list the charm.
+
+The result of the process is that:
+* if the review is successful, the charm is switched to listed mode, or
+* if the review is unsuccessful, the charm does not reach the required criteria
+  and the charm remains unlisted, until the issues are resolved.
+
+## Get ready
+
+Read the [documentation](https://documentation.ubuntu.com/ops/latest/howto/request-public-listing/)
+for detailed information about publicly listed charms, the review process, and
+the criteria for public listing.
+
+You can also use the tooling from this repository to see how close the charm is
+to passing a review. Note that some of the criteria can be checked automatically
+(and those will be when running the tool), but others will be manually checked
+by the reviewer (so you will need to evaluate readiness in those areas
+yourself).
+
+## Get started
+
+If the charm is ready for review,
+[open an issue in this repository](https://github.com/canonical/charmhub-listing-review/issues/new).
+
+## Next steps
+
+- Read the [docs](https://documentation.ubuntu.com/ops/latest/).
+- Read our [Code of conduct](https://ubuntu.com/community/code-of-conduct) and
+  join our [chat](https://matrix.to/#/#charmhub-ops:ubuntu.com) and
+  [forum](https://discourse.charmhub.io/) to get help polishing your charm or
+  with the public listing review process.
+- Read our [CONTRIBUTING guide](https://github.com/canonical/charmhub-listing-review/blob/main/CONTRIBUTING.md)
+  and contribute!


### PR DESCRIPTION
Replaces the template README with a real one, and adds a CONTRIBUTING.md doc.

These may need tweaking as the full system is brought together, but are intended to be a solid start that shouldn't need too much rework later.