### PR TITLE
ci: add initial GitHub issue template and workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/listing-request.yml
+++ b/.github/ISSUE_TEMPLATE/listing-request.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: Demo
       description: "Please provide a link to a demo video, or instructions on how to set up a demo over a call, or instructions on installing and trying out the charm via a tutorial."
-      placeholder: ex. https://www.youtube.com/watch?v=example
+      placeholder: https://www.youtube.com/watch?v=example
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/listing-request.yml
+++ b/.github/ISSUE_TEMPLATE/listing-request.yml
@@ -1,0 +1,62 @@
+name: Charmhub Listing Request
+description: Request a review for a charm to be publicly listed on Charmhub.
+labels:
+  - listing-request
+body:
+  - type: input
+    id: Name
+    attributes:
+      label: Charm name
+      description: "What is the name of the charm, as it appears on Charmhub?"
+      placeholder: ex. myworkload-k8s
+    validations:
+      required: true
+
+  - type: textarea
+    id: Demo
+    attributes:
+      label: Demo
+      description: "Please provide a link to a demo video, or instructions on how to set up a demo over a call, or instructions on installing and trying out the charm via a tutorial."
+      placeholder: ex. https://www.youtube.com/watch?v=example
+    validations:
+      required: true
+
+  - type: input
+    id: Repository-Link
+    attributes:
+      label: "Project Repository"
+      description: "Please provide the link to the charm's source code repository."
+    validations:
+      required: true
+
+  - type: input
+    id: CI-Linting
+    attributes:
+      label: "CI Linting"
+      description: "Please provide the link to the charm's CI workflow for linting and style checks."
+    validations:
+      required: true
+
+  - type: input
+    id: CI-Release
+    attributes:
+      label: "CI Release"
+      description: "Please provide the link to the charm's CI workflow for publishing to Charmhub."
+    validations:
+      required: true
+
+  - type: input
+    id: CI-Integration
+    attributes:
+      label: "CI Integration Tests"
+      description: "Please provide the link to the charm's CI workflow for integration tests."
+    validations:
+      required: true
+
+  - type: input
+    id: Documentation-Link
+    attributes:
+      label: "Documentation Link"
+      description: "Please provide the link to the charm's documentation."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/listing-request.yml
+++ b/.github/ISSUE_TEMPLATE/listing-request.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       label: Charm name
       description: "What is the name of the charm, as it appears on Charmhub?"
-      placeholder: ex. myworkload-k8s
+      placeholder: myworkload-k8s
     validations:
       required: true
 

--- a/.github/workflows/review-request.yaml
+++ b/.github/workflows/review-request.yaml
@@ -1,0 +1,53 @@
+name: Review Listing Request
+
+on:
+  issues:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created, edited]
+
+permissions: {}
+
+jobs:
+  review-listing-request:
+    if: contains(github.event.label.name, 'listing-request')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # These are used to extract the best practices from the docs.
+      - name: Checkout operator
+        uses: actions/checkout@v4
+        with:
+          repository: canonical/operator
+          path: operator
+          persist-credentials: false
+      - name: Checkout charmcraft
+        uses: actions/checkout@v4
+        with:
+          repository: canonical/charmcraft
+          path: charmcraft
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
+
+      - name: Install runners
+        run: |
+          sudo snap install just --classic
+          uv tool install tox --with tox-uv
+
+      - name: Authenticate GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Update issue summary and description
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            uv run src/charmhub_listing_review/update_issue.py --issue-number "${{ github.event.issue.number }}" --path-to-ops=operator --path-to-charmcraft=charmcraft

--- a/.github/workflows/review-request.yaml
+++ b/.github/workflows/review-request.yaml
@@ -2,7 +2,7 @@ name: Review Listing Request
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened, labeled, reopened]
   issue_comment:
     types: [created, edited]
 

--- a/reviewers.yaml
+++ b/reviewers.yaml
@@ -1,0 +1,25 @@
+reviewers:
+    # The key must be a GitHub username.
+    # The 'name' is currently unused, but is here for convenience.
+    "@benhoyt":
+        name: "Ben Hoyt"
+        team: "Charm Tech"
+    "@tonyandrewmeyer":
+        name: "Tony Meyer"
+        team: "Charm Tech"
+    "@IronCore864":
+        name: "Tiexin Guo"
+        team: "Charm Tech"
+    "@dimaqq":
+        name: "Dima Tisnek"
+        team: "Charm Tech"
+    "@dwilding":
+        name: "David Wilding"
+        team: "Charm Tech"
+    # As a Prof I, James isn't expected to do reviews, but for the evaluation
+    # cycle, he's helping out.
+    "@james-garner-canonical":
+        name: "James Garner"
+        team: "Charm Tech"
+    # Once the evaluation cycle is over, we'd add one person from each charming
+    # team here as well, and give them triage permissions in the repository.


### PR DESCRIPTION
This PR adds the initial GitHub infrastructure:

* An issue template that requests the required information when someone wants a review for public listing.
* A workflow that runs whenever an issue with the appropriate label is opened or has a label added, or when a comment is added or edited. This runs a script that will be added in a follow-up PR.