### PR TITLE
feat: add issue automation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,14 @@ ignore = [
 
     # Manual dict comprehension.
     "PERF403",
+
+    # Subprocess calls - not using an absolute path, and having some user content.
+    # There's a lot of calls to `gh` in the core processing here, and the code
+    # typically runs in CI, which mitigates most of the risk. We're rather just
+    # be careful and consider the risks of each call without having to scatter
+    # noqa's around.
+    "S603",
+    "S607",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
+    "PyYAML==6.*",
+    "requests~=2.32",
 ]
 
 [dependency-groups]
@@ -29,6 +31,9 @@ unit = [
     "pytest~=8.4",
     "coverage[toml]~=7.0",
 ]
+
+[project.scripts]
+update-issue = "charmhub_listing_review.update_issue:main"
 
 # Testing tools configuration
 [tool.coverage.run]

--- a/src/charmhub_listing_review/__init__.py
+++ b/src/charmhub_listing_review/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/charmhub_listing_review/__init__.py
+++ b/src/charmhub_listing_review/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Automation for the charm public listing review process."""

--- a/src/charmhub_listing_review/evaluate.py
+++ b/src/charmhub_listing_review/evaluate.py
@@ -46,7 +46,7 @@ def evaluate(
     security_url: str,
 ) -> list[str]:
     """Evaluate the charm for listing on Charmhub.
-    
+
     Returns a list of strings that should be included in a Markdown checklist.
     For example:
 

--- a/src/charmhub_listing_review/evaluate.py
+++ b/src/charmhub_listing_review/evaluate.py
@@ -164,7 +164,7 @@ def _clone_repo(charm_repo_url: str) -> pathlib.Path:
     """Clone the charm repository to a temporary directory."""
     temp_dir = tempfile.mkdtemp()
     try:
-        subprocess.run(  # noqa: S603  We should validate the safety of the URL, but also: in CI.
+        subprocess.run(
             ['/usr/bin/git', 'clone', '--depth', '1', charm_repo_url, temp_dir],
             check=True,
             stdout=subprocess.DEVNULL,
@@ -433,7 +433,7 @@ def charmcraft_tooling(repo_dir: pathlib.Path) -> str:
 
     for command in commands_to_run:
         try:
-            subprocess.check_output(command)  # noqa: S603
+            subprocess.check_output(command)
         except subprocess.CalledProcessError:
             return description
 

--- a/src/charmhub_listing_review/update_issue.py
+++ b/src/charmhub_listing_review/update_issue.py
@@ -145,6 +145,8 @@ The following checks are not required for listing, but are recommended for all c
     return ''.join(description)
 
 
+# TODO: It would be better to amend the docs so that we don't have these issues
+# than to have a manually curated set of practices to ignore.
 IGNORED_BEST_PRACTICES = {
     # This is covered by the more extensive items above. It's also duplicated in
     # the docs.
@@ -288,43 +290,89 @@ def assign_review(issue_number: int):
     return reviewer
 
 
-def main():
-    """Extract information from the issue and post/update a review comment."""
-    parser = argparse.ArgumentParser(
-        description='Update a GitHub issue for a charm listing review.'
+def update_gh_issue(issue_number: int, summary: str, comment: str):
+    # Update the issue title:
+    subprocess.run(  # noqa: S603
+        ['gh', 'issue', 'edit', str(issue_number), '--title', summary],  # noqa: S607
+        check=True,
     )
-    parser.add_argument(
-        '--issue-number', type=int, help='The issue number to update', required=True
-    )
-    parser.add_argument(
-        '--dry-run', action='store_true', help='Do not update the issue, just print the output'
-    )
-    parser.add_argument(
-        '--path-to-ops',
-        type=pathlib.Path,
-        default=pathlib.Path(__file__).parent.parent / 'operator',
-        help='Path to a clone of canonical/operator',
-    )
-    parser.add_argument(
-        '--path-to-charmcraft',
-        type=pathlib.Path,
-        default=pathlib.Path(__file__).parent.parent / 'charmcraft',
-        help='Path to a clone of canonical/charmcraft',
-    )
-    args = parser.parse_args()
 
-    issue_data = get_details_from_issue(args.issue_number)
-
-    summary = issue_summary(issue_data['name'])
-    comment = issue_comment(
-        issue_data['name'],
-        issue_data['demo_url'],
-        issue_data['ci_release_url'],
-        issue_data['ci_integration_url'],
-        issue_data['documentation_link'],
-        args.path_to_ops,
-        args.path_to_charmcraft,
+    # Assign the issue, if it is not already.
+    gh = subprocess.run(  # noqa: S603
+        ['gh', 'issue', 'view', str(issue_number), '--json', 'assignees'],
+        capture_output=True,
+        text=True,
     )
+    assignees = json.loads(gh.stdout.strip()).get('assignees', [])
+    if assignees:
+        manager = assignees[0]
+    else:
+        # If there are no assignees, then we need to assign the issue.
+        manager = assign_review(issue_number)
+    request_review = re.sub(
+        r'\s',
+        ' ',
+        f"""\
+@{manager} - please assign this review to someone in your team, and mention
+their name in a comment (for example, "Hi @canonical-person, please review this
+charm"). Please choose someone that will have time to complete the initial
+review within the next three working days.
+""",
+    )
+    comment = f'{comment}\n\n{request_review}'
+
+    existing_comments = subprocess.run(  # noqa: S603
+        ['gh', 'issue', 'view', str(issue_number), '--json', 'comments'],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    existing_comments = json.loads(existing_comments.stdout.strip()).get('comments', [])
+    if not existing_comments:
+        # Create a new comment.
+        subprocess.run(  # noqa: S603
+            ['gh', 'issue', 'comment', str(issue_number), '--body', comment],  # noqa: S607
+            check=True,
+        )
+        return
+
+    # Update the status with any checks from the reviewer.
+    reviewer = None
+    for existing_comment in existing_comments:
+        if existing_comment['author']['login'] == manager:
+            reviewer = body.split('@', 1)[1].split(' ')[0]
+            continue
+        if existing_comment['author']['login'] != reviewer:
+            continue
+        for line in existing_comment['body'].splitlines():
+            # We ignore everything that isn't in the checklist format,
+            # so that the reviewer can leave free-form comments.
+            if not line.startswith('* [ ]') and not line.startswith('* [x]'):
+                continue
+            if line.startswith('* [ ]') and line.replace('* [ ]', '* [x]') in comment:
+                # We are unticking this item, unfortunately.
+                comment = comment.replace(line.replace('* [ ]', '* [x]'), line)
+            elif line.startswith('* [x]') and line.replace('* [x]', '* [ ]') in comment:
+                # We are ticking this item, yay!
+                comment = comment.replace(line.replace('* [x]', '* [ ]'), line)
+
+    # Update the first comment with the new content.
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            'gh',
+            'issue',
+            'comment',
+            str(issue_number),
+            '--edit-last',  # comment of the current user
+            existing_comments.splitlines()[0],
+            '--body',
+            comment,
+        ],
+        check=True,
+    )
+
+
+def apply_automated_checks(issue_data: _IssueData, comment: str):
     results = evaluate.evaluate(
         issue_data['name'],
         issue_data['project_repo'],
@@ -342,83 +390,54 @@ def main():
             comment = comment.replace(result, result.replace('* [ ]', '* [x]'))
         elif result.replace('* [x]', '* [ ]') in comment:
             comment = comment.replace(result.replace('* [x]', '* [ ]'), result)
+    return comment
+
+
+def main():
+    """Extract information from the issue and post/update a review comment."""
+    parser = argparse.ArgumentParser(
+        description='Update a GitHub issue for a charm listing review.'
+    )
+    parser.add_argument(
+        '--issue-number', type=int, help='The issue number to update', required=True
+    )
+    parser.add_argument(
+        '--dry-run', action='store_true', help='Do not update the issue, just print the output'
+    )
+    parser.add_argument(
+        '--path-to-ops',
+        type=pathlib.Path,
+        default=pathlib.Path(__file__).parent.parent / 'operator',
+        help='Path to a clone of canonical/operator (to get best practices)',
+    )
+    parser.add_argument(
+        '--path-to-charmcraft',
+        type=pathlib.Path,
+        default=pathlib.Path(__file__).parent.parent / 'charmcraft',
+        help='Path to a clone of canonical/charmcraft (to get best practices)',
+    )
+    args = parser.parse_args()
+
+    issue_data = get_details_from_issue(args.issue_number)
+
+    summary = issue_summary(issue_data['name'])
+    comment = issue_comment(
+        issue_data['name'],
+        issue_data['demo_url'],
+        issue_data['ci_release_url'],
+        issue_data['ci_integration_url'],
+        issue_data['documentation_link'],
+        args.path_to_ops,
+        args.path_to_charmcraft,
+    )
+    comment = apply_automated_checks(issue_data)
 
     if args.dry_run:
         print(summary)
         print()
         print(comment)
     else:
-        # Update the issue title:
-        subprocess.run(  # noqa: S603
-            ['gh', 'issue', 'edit', str(args.issue_number), '--title', summary],  # noqa: S607
-            check=True,
-        )
-        # If there is already a first comment that we posted, then update it with the latest
-        # content. Otherwise, create a new comment.
-        existing_comments = subprocess.run(  # noqa: S603
-            ['gh', 'issue', 'view', str(args.issue_number), '--json', 'comments'],  # noqa: S607
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        existing_comments = json.loads(existing_comments.stdout.strip()).get('comments', [])
-        if existing_comments:
-            # Update the status with any checks from the reviewer.
-            manager = None
-            reviewer = None
-            for existing_comment in existing_comments:
-                body = existing_comment['body']
-                if "please assign this review to someone in your team" in body:
-                    manager = body.rsplit('@', 2)[1].split(' ')[0]
-                    continue
-                if manager is not None and f"@{manager}" in body:
-                    reviewer = body.split('@', 1)[1].split(' ')[0]
-                    continue
-                if existing_comment['author'] == reviewer:
-                    for line in body.splitlines():
-                        # We ignore everything that isn't in the checklist format,
-                        # so that the reviewer can leave free-form comments.
-                        if not line.startswith("* [ ]") and not line.startswith("* [x]"):
-                            continue
-                        if line.startswith('* [ ]') and line.replace('* [ ]', '* [x]') in comment:
-                            # We are unticking this item, unfortunately.
-                            comment = comment.replace(line.replace('* [ ]', '* [x]'), line)
-                        elif line.startswith('* [x]') and line.replace('* [x]', '* [ ]') in comment:
-                            # We are ticking this item, yay!
-                            comment = comment.replace(line.replace('* [x]', '* [ ]'), line)
-            # Update the first comment with the new content.
-            subprocess.run(  # noqa: S603
-                [  # noqa: S607
-                    'gh',
-                    'issue',
-                    'comment',
-                    str(args.issue_number),
-                    '--edit-last',  # comment of the current user
-                    existing_comments.splitlines()[0],
-                    '--body',
-                    comment,
-                ],
-                check=True,
-            )
-        else:
-            # Assign the issue.
-            reviewer = assign_review(args.issue_number)
-            request_review = re.sub(
-                r'\s',
-                ' ',
-                f"""\
-@{reviewer} - please assign this review to someone in your team, and mention
-their name in a comment (for example, "Hi @canonical-person, please review this
-charm"). Please choose someone that will have time to complete the initial
-review within the next three working days.
-""",
-            )
-            comment = f"{comment}\n\n{request_review}"
-            # Create a new comment.
-            subprocess.run(  # noqa: S603
-                ['gh', 'issue', 'comment', str(args.issue_number), '--body', comment],  # noqa: S607
-                check=True,
-            )
+        update_gh_issue(args.issue_number, summary, comment)
 
 
 if __name__ == '__main__':

--- a/src/charmhub_listing_review/update_issue.py
+++ b/src/charmhub_listing_review/update_issue.py
@@ -217,16 +217,15 @@ class _IssueData(TypedDict):
 def get_details_from_issue(issue_number: int):
     """Fetch details from the issue number using the GitHub CLI.
 
-    Requires `gh` CLI to be installed and authenticated, and `jq` to be
-    available.
+    Requires `gh` CLI to be installed and authenticated.
     """
     result = subprocess.run(  # noqa: S603
-        ['gh', 'issue', 'view', str(issue_number), '--json', 'body', '--jq', '.body'],  # noqa: S607
+        ['gh', 'issue', 'view', str(issue_number), '--json', 'body'],  # noqa: S607
         capture_output=True,
         text=True,
         check=True,
     )
-    body = result.stdout
+    body = json.loads(result.stdout)['body']
 
     # Define the fields to extract and their headings
     fields = {

--- a/src/charmhub_listing_review/update_issue.py
+++ b/src/charmhub_listing_review/update_issue.py
@@ -34,6 +34,7 @@ import pathlib
 import random
 import re
 import subprocess  # noqa: S404
+import sys
 from typing import TypedDict, cast
 
 import yaml
@@ -341,9 +342,16 @@ review within the next three working days.
     reviewer = None
     for existing_comment in existing_comments:
         if existing_comment['author']['login'] == manager:
-            reviewer = existing_comment['body'].split('@', 1)[1].split(' ')[0]
-            continue
-        if existing_comment['author']['login'] != reviewer:
+            try:
+                reviewer = existing_comment['body'].split('@', 1)[1].split(' ')[0]
+            except IndexError:
+                print(
+                    f"Could not find reviewer in comment {existing_comment['body']}",
+                    file=sys.stderr
+                )
+            else:
+                continue
+        if reviewer is None or existing_comment['author']['login'] != reviewer:
             continue
         for line in existing_comment['body'].splitlines():
             # We ignore everything that isn't in the checklist format,

--- a/src/charmhub_listing_review/update_issue.py
+++ b/src/charmhub_listing_review/update_issue.py
@@ -1,0 +1,425 @@
+#! /usr/bin/env python3
+
+# /// script
+# dependencies = [
+#   "pyyaml",
+#   "requests"
+# ]
+# ///
+
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Update a GitHub issue for a charm listing review with the current checklist.
+
+Issues for listing review requests are created by the usual GitHub issue
+creation process, with the help of the issue template. This script updates the
+created issue to be user-friendly, and to include the current checklist.
+"""
+
+import argparse
+import json
+import pathlib
+import random
+import re
+import subprocess  # noqa: S404
+from typing import TypedDict, cast
+
+import yaml
+
+import evaluate
+
+BEST_PRACTICE_RE_MD = re.compile(
+    r'```{admonition} Best practice\s*(?:.*?\n)?([\s\S]*?)```',
+    re.MULTILINE,
+)
+BEST_PRACTICE_RE_REST = re.compile(
+    r'^\.\. admonition:: Best practice\s*\n\s*:class: hint\s*\n\s*\n([\s\S]*?)(?=\n\.\. |\n\n|\Z)',
+    re.MULTILINE,
+)
+
+
+def issue_summary(name: str):
+    """Provide a suitable issue title."""
+    return f'Review `{name}` for public listing on Charmhub'
+
+
+def issue_comment(
+    name: str,
+    demo_url: str,
+    ci_release_url: str,
+    ci_integration_url: str,
+    documentation_link: str,
+    path_to_ops: pathlib.Path,
+    path_to_charmcraft: pathlib.Path,
+):
+    """Provide a suitable issue comment.
+
+    The comment outlines what is required by the reviewer and what the current
+    progress against the review is.
+    """
+    # fmt: off
+    description = [
+        f"""
+Please review the charm by checking each of the items in the following checklist.
+
+If you find other improvements or fixes that could be made to the charm, feel free to suggest those, but **they do not block listing**. If you find something that's missing from the review checklist or best practices, please separately suggest that (see [CONTRIBUTING.md](../CONTRIBUTING.md)) so that we can keep the review process consistent.
+
+See the [README](../README.md) for more information about the charm listing review process.
+
+When reviewing test coverage of the charm, note that:
+
+* Unit tests are recommended, but *not* required.
+* A minimal set of integration tests is required, as outlined in the checklist.
+* There is no minimum for test coverage. We suggest that tests cover at least all configuration options and actions, as well as the observed Juju events, but this is not a requirement for listing.
+* Some charms may have additional tests in an external location, particularly if the charm has specific resource requirements (such as specific hardware).
+
+Please provide your review within *three working days*. If blocking issues are found, please help the author work through those, and respond to any follow-up posts within *one working day*.
+
+## Listing requirements
+
+* [ ] The charm does what it is meant to do, per the [demo or tutorial]({demo_url}).
+* [ ] The [charm's page on Charmhub](https://charmhub.io/{name}) provides a quality impression. The overall appearance looks good and the [documentation]({documentation_link}) looks reasonable.
+* [ ] The charm has an icon.
+* [ ] [Automated releasing]({ci_release_url}) to unstable channels exists
+* [ ] [Integration tests]({ci_integration_url}) exist, are run on every change to the default branch, and are passing. At minimum, the tests verify that the charm can be deployed and ends up in a success state, and that the charm can be integrated with at least one example for each 'provides' and 'requires' specified (including optional, excluding tracing) ending up in a success state. The tests should be run with `charmcraft test`.
+""".strip()  # noqa: E501
+    ]
+    description.append('\n\n')
+    description.append(
+        """
+### Documentation
+
+A charm's documentation should focus on the charm itself. For workload-specific or Juju-related content, link to the appropriate upstream documentation. A smaller charm can have single-page documentation for its description. A bigger charm should include a full Diátaxis navigation tree. Check that the charm has documentation that covers:
+* [ ] How to use the charm, including configuration, limitations, and deviations in behaviour from the “non-charmed” version of the application.
+* [ ] How to modify the charm
+* [ ] A concise summary of the charm in the `charmcraft.yaml` 'summary' field, and a more detailed description in the `charmcraft.yaml` 'description' field.
+""".strip(),  # noqa: E501
+    )
+
+    # fmt: on
+    best_practices = find_best_practices(
+        path_to_ops=path_to_ops, path_to_charmcraft=path_to_charmcraft
+    )
+    if best_practices:
+        description.append('\n\n')
+        description.append(
+            f"""
+### Best practices
+
+The following best practices are recommended for all charms, and are also
+required for listing.
+
+{'\n'.join(('* [ ] ' + p) for p in best_practices)}
+""".strip()
+        )
+
+    description.append('\n\n')
+    description.append(
+        """
+## Additional checks
+
+The following checks are not required for listing, but are recommended for all charms.
+
+* [ ] A user can deploy the charm with a sensible default configuration.
+* [ ] The charm exposes provides / requires interfaces for integration ready to be adopted by the ecosystem.
+* [ ] The charm upgrades the application safely, preserving data and settings, and minimising downtime.
+* [ ] The charm supports scaling up and down, if the application permits or supports it.
+* [ ] The charm supports backup and restore, if the application permits or supports it.
+* [ ] The charm is integrated with observability, including metrics, alerting, and logging.
+* [ ] The model-config `juju-http-proxy`, `juju-https-proxy`, and `juju-no-proxy` options should influence the charm's behavior when the charm or charm workload makes any HTTP request.
+""".strip()  # noqa: E501
+    )
+
+    return ''.join(description)
+
+
+IGNORED_BEST_PRACTICES = {
+    # This is covered by the more extensive items above. It's also duplicated in
+    # the docs.
+    '* [ ] The quality assurance pipeline of a charm should be automated using a '
+    'continuous integration (CI) system.',
+    # This is duplicated by another best practice note.
+    "* [ ] If you're setting up a ``git`` repository: name it using the pattern "
+    '``<charm name>-operator``. For the charm name, see :ref:`specify-a-name`.',
+    # These don't seem like best practice notes -- we should adjust the docs.
+    '* [ ] Smaller charm documentation examples:',
+    '* [ ] Bigger charm documentation examples:',
+}
+
+
+def extract_best_practice_blocks(file_path: pathlib.Path):
+    """Extracts 'Best practice' blocks from a file."""
+    remove_pattern: str | None = None
+    matches: list[str] = []
+    content = file_path.read_text()
+    if file_path.suffix == '.md':
+        matches = BEST_PRACTICE_RE_MD.findall(content)
+        remove_pattern = r'^:class: hint\s*\n'
+    elif file_path.suffix == '.rst':
+        matches = BEST_PRACTICE_RE_REST.findall(content)
+        remove_pattern = r'^\s+'
+    assert remove_pattern is not None, 'Unsupported file type for best practices extraction.'
+    if not matches:
+        return matches
+    return [
+        re.sub(remove_pattern, '', match, flags=re.MULTILINE).strip().replace('\n', ' ')
+        for match in matches
+    ]
+
+
+def find_best_practices(path_to_ops: pathlib.Path, path_to_charmcraft: pathlib.Path):
+    """Recursively located best practice blocks in Ops and Charmcraft."""
+    checklist: list[str] = []
+    for directory in (path_to_ops, path_to_charmcraft):
+        for file_path in directory.rglob('*'):
+            if file_path.suffix in ('.md', '.rst'):
+                practices = (
+                    practice
+                    for practice in extract_best_practice_blocks(file_path)
+                    if practice not in IGNORED_BEST_PRACTICES
+                )
+                checklist.extend(practices)
+    checklist.sort()
+    return checklist
+
+
+class _IssueData(TypedDict):
+    """Typed dictionary for issue data."""
+
+    name: str
+    demo_url: str
+    project_repo: str
+    ci_linting: str
+    ci_release_url: str
+    ci_integration_url: str
+    documentation_link: str
+    contribution_link: str
+    license_link: str
+    security_link: str
+
+
+def get_details_from_issue(issue_number: int):
+    """Fetch details from the issue number using the GitHub CLI.
+
+    Requires `gh` CLI to be installed and authenticated, and `jq` to be
+    available.
+    """
+    result = subprocess.run(  # noqa: S603
+        ['gh', 'issue', 'view', str(issue_number), '--json', 'body', '--jq', '.body'],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    body = result.stdout
+
+    # Define the fields to extract and their headings
+    fields = {
+        'name': '### Charm name',
+        'demo_url': '### Demo',
+        'project_repo': '### Project Repository',
+        'ci_linting': '### CI Linting',
+        'ci_release_url': '### CI Release',
+        'ci_integration_url': '### CI Integration Tests',
+        'documentation_link': '### Documentation Link',
+    }
+
+    # Extract values for each field
+    issue_data: dict[str, bool | str | None] = {}
+    for key, heading in fields.items():
+        pattern = rf'{re.escape(heading)}\s*\n([^\n]*)'
+        match = re.search(pattern, body)
+        if match:
+            value = match.group(1).strip()
+            issue_data[key] = value
+        else:
+            issue_data[key] = None
+
+    # These have expected filenames, so we use those rather than require the author provide them.
+    # This is quite specific to GitHub, but we can add support for other platforms if required,
+    # and if they aren't found then the reviewer just has to locate them themselves.
+    issue_data['contribution_link'] = f'{issue_data["project_repo"]}/blob/main/CONTRIBUTING.md'
+    issue_data['license_link'] = f'{issue_data["project_repo"]}/blob/main/LICENSE'
+    issue_data['security_link'] = f'{issue_data["project_repo"]}/blob/main/SECURITY.md'
+
+    return cast('_IssueData', issue_data)
+
+
+def assign_review(issue_number: int):
+    """Assign the issue to a team.
+
+    We assign the issue to a single person (generally the manager) from a
+    charming team. The expectation is that they will then delegate the actual
+    review to a member of their team. The manager has overall responsibility for
+    ensuring that the review is completed on time (with Charm Tech responsible
+    for keeping the manager accountable).
+
+    The manager can't assign the issue directly to a reviewer (without having
+    every possible reviewer added as a collaborator on the repository), so they
+    are expected to simply ping them in a comment. Once they have submitted
+    their review, the author can interact with them in the usual way.
+    """
+    reviewers_file = pathlib.Path(__file__).parent.parent.parent / 'reviewers.yaml'
+    with reviewers_file.open('r') as f:
+        reviewers_data = yaml.safe_load(f)
+    reviewers = reviewers_data['reviewers']
+    teams = [info['team'] for info in reviewers.values()]
+    team = random.choice(teams)  # noqa: S311
+    # If there happen to be multiple people in a team, then randomly pick among
+    # them.
+    team_reviewers = [name for name, info in reviewers.items() if info['team'] == team]
+    reviewer = random.choice(team_reviewers)  # noqa: S311
+
+    subprocess.run(  # noqa: S603
+        ['gh', 'issue', 'edit', str(issue_number), '--assignee', reviewer],  # noqa: S607
+        check=True,
+    )
+    return reviewer
+
+
+def main():
+    """Extract information from the issue and post/update a review comment."""
+    parser = argparse.ArgumentParser(
+        description='Update a GitHub issue for a charm listing review.'
+    )
+    parser.add_argument(
+        '--issue-number', type=int, help='The issue number to update', required=True
+    )
+    parser.add_argument(
+        '--dry-run', action='store_true', help='Do not update the issue, just print the output'
+    )
+    parser.add_argument(
+        '--path-to-ops',
+        type=pathlib.Path,
+        default=pathlib.Path(__file__).parent.parent / 'operator',
+        help='Path to a clone of canonical/operator',
+    )
+    parser.add_argument(
+        '--path-to-charmcraft',
+        type=pathlib.Path,
+        default=pathlib.Path(__file__).parent.parent / 'charmcraft',
+        help='Path to a clone of canonical/charmcraft',
+    )
+    args = parser.parse_args()
+
+    issue_data = get_details_from_issue(args.issue_number)
+
+    summary = issue_summary(issue_data['name'])
+    comment = issue_comment(
+        issue_data['name'],
+        issue_data['demo_url'],
+        issue_data['ci_release_url'],
+        issue_data['ci_integration_url'],
+        issue_data['documentation_link'],
+        args.path_to_ops,
+        args.path_to_charmcraft,
+    )
+    results = evaluate.evaluate(
+        issue_data['name'],
+        issue_data['project_repo'],
+        issue_data['ci_linting'],
+        issue_data['contribution_link'],
+        issue_data['license_link'],
+        issue_data['security_link'],
+    )
+    for result in results:
+        if result.replace('* [ ]', '* [x]') in comment:
+            # TODO: Should we support unticking? The reviewer needs to be able to override
+            # the checklist. However, the publisher should not be able to override and one way
+            # to enforce that is to have the automatic check 'win' (we would also need to
+            # trigger if the comment changes and not loop).
+            comment = comment.replace(result, result.replace('* [ ]', '* [x]'))
+        elif result.replace('* [x]', '* [ ]') in comment:
+            comment = comment.replace(result.replace('* [x]', '* [ ]'), result)
+
+    if args.dry_run:
+        print(summary)
+        print()
+        print(comment)
+    else:
+        # Update the issue title:
+        subprocess.run(  # noqa: S603
+            ['gh', 'issue', 'edit', str(args.issue_number), '--title', summary],  # noqa: S607
+            check=True,
+        )
+        # If there is already a first comment that we posted, then update it with the latest
+        # content. Otherwise, create a new comment.
+        existing_comments = subprocess.run(  # noqa: S603
+            ['gh', 'issue', 'view', str(args.issue_number), '--json', 'comments'],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        existing_comments = json.loads(existing_comments.stdout.strip()).get('comments', [])
+        if existing_comments:
+            # Update the status with any checks from the reviewer.
+            manager = None
+            reviewer = None
+            for existing_comment in existing_comments:
+                body = existing_comment['body']
+                if "please assign this review to someone in your team" in body:
+                    manager = body.rsplit('@', 2)[1].split(' ')[0]
+                    continue
+                if manager is not None and f"@{manager}" in body:
+                    reviewer = body.split('@', 1)[1].split(' ')[0]
+                    continue
+                if existing_comment['author'] == reviewer:
+                    for line in body.splitlines():
+                        # We ignore everything that isn't in the checklist format,
+                        # so that the reviewer can leave free-form comments.
+                        if not line.startswith("* [ ]") and not line.startswith("* [x]"):
+                            continue
+                        if line.startswith('* [ ]') and line.replace('* [ ]', '* [x]') in comment:
+                            # We are unticking this item, unfortunately.
+                            comment = comment.replace(line.replace('* [ ]', '* [x]'), line)
+                        elif line.startswith('* [x]') and line.replace('* [x]', '* [ ]') in comment:
+                            # We are ticking this item, yay!
+                            comment = comment.replace(line.replace('* [x]', '* [ ]'), line)
+            # Update the first comment with the new content.
+            subprocess.run(  # noqa: S603
+                [  # noqa: S607
+                    'gh',
+                    'issue',
+                    'comment',
+                    str(args.issue_number),
+                    '--edit-last',  # comment of the current user
+                    existing_comments.splitlines()[0],
+                    '--body',
+                    comment,
+                ],
+                check=True,
+            )
+        else:
+            # Assign the issue.
+            reviewer = assign_review(args.issue_number)
+            request_review = re.sub(
+                r'\s',
+                ' ',
+                f"""\
+@{reviewer} - please assign this review to someone in your team, and mention
+their name in a comment (for example, "Hi @canonical-person, please review this
+charm"). Please choose someone that will have time to complete the initial
+review within the next three working days.
+""",
+            )
+            comment = f"{comment}\n\n{request_review}"
+            # Create a new comment.
+            subprocess.run(  # noqa: S603
+                ['gh', 'issue', 'comment', str(args.issue_number), '--body', comment],  # noqa: S607
+                check=True,
+            )
+
+
+if __name__ == '__main__':
+    main()

--- a/src/charmhub_listing_review/update_issue.py
+++ b/src/charmhub_listing_review/update_issue.py
@@ -41,7 +41,6 @@ import yaml
 
 from .evaluate import evaluate
 
-
 BEST_PRACTICE_RE_MD = re.compile(
     r'```{admonition} Best practice\s*(?:.*?\n)?([\s\S]*?)```',
     re.MULTILINE,
@@ -219,8 +218,8 @@ def get_details_from_issue(issue_number: int):
 
     Requires `gh` CLI to be installed and authenticated.
     """
-    result = subprocess.run(  # noqa: S603
-        ['gh', 'issue', 'view', str(issue_number), '--json', 'body'],  # noqa: S607
+    result = subprocess.run(
+        ['gh', 'issue', 'view', str(issue_number), '--json', 'body'],
         capture_output=True,
         text=True,
         check=True,
@@ -259,7 +258,7 @@ def get_details_from_issue(issue_number: int):
     return cast('_IssueData', issue_data)
 
 
-def assign_review(issue_number: int, dry_run: bool=False):
+def assign_review(issue_number: int, dry_run: bool = False):
     """Assign the issue to a team.
 
     We assign the issue to a single person (generally the manager) from a
@@ -285,36 +284,33 @@ def assign_review(issue_number: int, dry_run: bool=False):
     reviewer = random.choice(team_reviewers)  # noqa: S311
 
     if not dry_run:
-        subprocess.run(  # noqa: S603
-            ['gh', 'issue', 'edit', str(issue_number), '--add-assignee', reviewer[1:]],  # noqa: S607
+        subprocess.run(
+            ['gh', 'issue', 'edit', str(issue_number), '--add-assignee', reviewer[1:]],
             check=True,
         )
     return reviewer
 
 
 def update_gh_issue(issue_number: int, summary: str, comment: str, dry_run: bool = False):
+    """Update the specified GitHub issue with the latest generated comment."""
     # Update the issue title.
     if dry_run:
         print(summary)
         print()
     else:
-        subprocess.run(  # noqa: S603
-            ['gh', 'issue', 'edit', str(issue_number), '--title', summary],  # noqa: S607
+        subprocess.run(
+            ['gh', 'issue', 'edit', str(issue_number), '--title', summary],
             check=True,
         )
 
     # Assign the issue, if it is not already.
-    gh = subprocess.run(  # noqa: S603
+    gh = subprocess.run(
         ['gh', 'issue', 'view', str(issue_number), '--json', 'assignees'],
         capture_output=True,
         text=True,
     )
     assignees = json.loads(gh.stdout.strip()).get('assignees', [])
-    if assignees:
-        manager = assignees[0]['login']
-    else:
-        # If there are no assignees, then we need to assign the issue.
-        manager = assign_review(issue_number, dry_run)
+    manager = assignees[0]['login'] if assignees else assign_review(issue_number, dry_run)
     request_review = re.sub(
         r'\s',
         ' ',
@@ -327,8 +323,8 @@ review within the next three working days.
     )
     comment = f'{comment}\n\n{request_review}'
 
-    existing_comments = subprocess.run(  # noqa: S603
-        ['gh', 'issue', 'view', str(issue_number), '--json', 'comments'],  # noqa: S607
+    existing_comments = subprocess.run(
+        ['gh', 'issue', 'view', str(issue_number), '--json', 'comments'],
         capture_output=True,
         text=True,
         check=True,
@@ -339,8 +335,8 @@ review within the next three working days.
         if dry_run:
             print(comment)
         else:
-            subprocess.run(  # noqa: S603
-                ['gh', 'issue', 'comment', str(issue_number), '--body', comment],  # noqa: S607
+            subprocess.run(
+                ['gh', 'issue', 'comment', str(issue_number), '--body', comment],
                 check=True,
             )
         return
@@ -376,8 +372,8 @@ review within the next three working days.
     if dry_run:
         print(comment)
     else:
-        subprocess.run(  # noqa: S603
-            [  # noqa: S607
+        subprocess.run(
+            [
                 'gh',
                 'issue',
                 'comment',
@@ -391,6 +387,7 @@ review within the next three working days.
 
 
 def apply_automated_checks(issue_data: _IssueData, comment: str):
+    """Adjust the comment to tick or untick items based on automated checks."""
     results = evaluate(
         issue_data['name'],
         issue_data['project_repo'],

--- a/tests/unit/test_evaluate.py
+++ b/tests/unit/test_evaluate.py
@@ -22,21 +22,21 @@ import charmhub_listing_review.evaluate as evaluate
 
 
 @pytest.mark.parametrize(
-    "name,expected",
+    'name,expected',
     [
-        ("valid-name", True),
-        ("Invalid-Name", False),
-        ("invalid--name", False),
-        ("invalid_name", False),
-        ("validname", True),
-        ("-invalid", False),
-        ("invalid-", False),
+        ('valid-name', True),
+        ('Invalid-Name', False),
+        ('invalid--name', False),
+        ('invalid_name', False),
+        ('validname', True),
+        ('-invalid', False),
+        ('invalid-', False),
     ],
 )
-@pytest.mark.parametrize("method", ["action_names", "option_names"])
+@pytest.mark.parametrize('method', ['action_names', 'option_names'])
 def test_check_action_and_config_names(name, expected, method, tmp_path):
-    charmcraft_yaml = tmp_path / "charmcraft.yaml"
-    if method == "action_names":
+    charmcraft_yaml = tmp_path / 'charmcraft.yaml'
+    if method == 'action_names':
         yaml_content = f"""
 name: test-charm
 actions:
@@ -51,130 +51,130 @@ config:
 """
     charmcraft_yaml.write_text(yaml_content)
     result = getattr(evaluate, method)(tmp_path)
-    assert (result.startswith("* [x]")) == expected
+    assert (result.startswith('* [x]')) == expected
 
 
 @pytest.mark.parametrize(
-    "charm_name,expected",
+    'charm_name,expected',
     [
-        ("valid-name", True),
-        ("Invalid-Name", False),
+        ('valid-name', True),
+        ('Invalid-Name', False),
     ],
 )
 def test_check_charm_name(charm_name, expected):
     result = evaluate.check_charm_name(charm_name)
-    assert (result.startswith("* [x]")) == expected
+    assert (result.startswith('* [x]')) == expected
 
 
-@mock.patch("requests.head")
-@pytest.mark.parametrize("status,expected", [(True, True), (False, False)])
+@mock.patch('requests.head')
+@pytest.mark.parametrize('status,expected', [(True, True), (False, False)])
 def test_contribution_guidelines(mock_head, status, expected):
     mock_head.return_value.ok = status
-    result = evaluate.contribution_guidelines("url")
-    assert (result.startswith("* [x]")) == expected
+    result = evaluate.contribution_guidelines('url')
+    assert (result.startswith('* [x]')) == expected
 
 
-@mock.patch("requests.get")
-@pytest.mark.parametrize("license_hash", evaluate._known_licenses)
+@mock.patch('requests.get')
+@pytest.mark.parametrize('license_hash', evaluate._known_licenses)
 def test_license_statement_known_license(mock_get, license_hash):
     class Response:
         ok = True
-        text = "Some License Version x.0, January 1979"
+        text = 'Some License Version x.0, January 1979'
 
     mock_get.return_value = Response()
-    with mock.patch("hashlib.sha512") as mock_hash:
+    with mock.patch('hashlib.sha512') as mock_hash:
         mock_hash.return_value.hexdigest.return_value = license_hash
-        result = evaluate.license_statement("url")
-        assert result.startswith("* [x]")
+        result = evaluate.license_statement('url')
+        assert result.startswith('* [x]')
 
 
-@mock.patch("requests.get")
+@mock.patch('requests.get')
 def test_license_statement_fails(mock_get):
     mock_get.return_value.ok = False
-    result = evaluate.license_statement("url")
-    assert result.startswith("* [ ]")
+    result = evaluate.license_statement('url')
+    assert result.startswith('* [ ]')
 
     class Response:
         ok = True
-        text = "Some Unknown License"
+        text = 'Some Unknown License'
 
     mock_get.return_value = Response()
     mock_get.return_value.ok = True
-    result = evaluate.license_statement("url")
-    assert result.startswith("* [ ]")
+    result = evaluate.license_statement('url')
+    assert result.startswith('* [ ]')
 
 
-@mock.patch("requests.head")
-@pytest.mark.parametrize("status,expected", [(True, True), (False, False)])
+@mock.patch('requests.head')
+@pytest.mark.parametrize('status,expected', [(True, True), (False, False)])
 def test_security_doc(mock_head, status, expected):
     mock_head.return_value.ok = status
-    result = evaluate.security_doc("url")
-    assert result.startswith("* [x]") == expected
+    result = evaluate.security_doc('url')
+    assert result.startswith('* [x]') == expected
 
 
 @pytest.mark.parametrize(
-    "url,charm_name,expected",
+    'url,charm_name,expected',
     [
-        ("https://github.com/canonical/foo-operator", "foo", True),
-        ("https://github.com/canonical/bar", "foo", False),
+        ('https://github.com/canonical/foo-operator', 'foo', True),
+        ('https://github.com/canonical/bar', 'foo', False),
     ],
 )
 def test_repository_name(url, charm_name, expected):
     result = evaluate.repository_name(url, charm_name)
-    assert (result.startswith("* [x]")) == expected
+    assert (result.startswith('* [x]')) == expected
 
 
 def test_python_requires_version(tmp_path):
-    pyproject = tmp_path / "pyproject.toml"
+    pyproject = tmp_path / 'pyproject.toml'
     pyproject.write_text("""
     [project]
     requires-python = ">=3.10"
     """)
     result = evaluate.python_requires_version(tmp_path)
-    assert result.startswith("* [x]")
+    assert result.startswith('* [x]')
 
 
 def test_missing_python_requires_version(tmp_path):
-    pyproject = tmp_path / "pyproject.toml"
+    pyproject = tmp_path / 'pyproject.toml'
     pyproject.write_text("""
     [project]
     name = "foo"
     """)
     result = evaluate.python_requires_version(tmp_path)
-    assert result.startswith("* [ ]")
+    assert result.startswith('* [ ]')
 
 
-@pytest.mark.parametrize("lock_file", ["uv.lock", "poetry.lock"])
+@pytest.mark.parametrize('lock_file', ['uv.lock', 'poetry.lock'])
 def test_repo_has_lock_file(tmp_path, lock_file):
-    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'foo'\n")
-    (tmp_path / lock_file).write_text("lock")
+    (tmp_path / 'pyproject.toml').write_text("[project]\nname = 'foo'\n")
+    (tmp_path / lock_file).write_text('lock')
     result = evaluate.repo_has_lock_file(tmp_path)
-    assert result.startswith("* [x]")
+    assert result.startswith('* [x]')
 
-    tmp2 = tmp_path / "no_repo"
+    tmp2 = tmp_path / 'no_repo'
     tmp2.mkdir()
-    (tmp2 / "pyproject.toml").write_text("[project]\nname = 'foo'\n")
+    (tmp2 / 'pyproject.toml').write_text("[project]\nname = 'foo'\n")
     result = evaluate.repo_has_lock_file(tmp2)
-    assert result.startswith("* [ ]")
+    assert result.startswith('* [ ]')
 
 
 def test_charm_has_icon(tmp_path):
-    icon = tmp_path / "icon.svg"
+    icon = tmp_path / 'icon.svg'
     icon.write_text('<svg width="100" height="100"></svg>')
     result = evaluate.charm_has_icon(tmp_path)
-    assert result.startswith("* [x]")
+    assert result.startswith('* [x]')
 
     icon.write_text('<svg viewBox="0 0 100 100"></svg>')
     result = evaluate.charm_has_icon(tmp_path)
-    assert result.startswith("* [x]")
+    assert result.startswith('* [x]')
 
     icon.write_text('<svg width="99" height="99"></svg>')
     result = evaluate.charm_has_icon(tmp_path)
-    assert result.startswith("* [ ]")
+    assert result.startswith('* [ ]')
 
 
 @pytest.mark.parametrize(
-    "yaml_content,link_ok,expected_checked",
+    'yaml_content,link_ok,expected_checked',
     [
         # Success: all fields present, links ok.
         (
@@ -245,19 +245,17 @@ links:
         ),
     ],
 )
-@mock.patch("requests.head")
-def test_metadata_links_parametrized(
-    mock_head, tmp_path, yaml_content, link_ok, expected_checked
-):
-    charmcraft_yaml = tmp_path / "charmcraft.yaml"
+@mock.patch('requests.head')
+def test_metadata_links_parametrized(mock_head, tmp_path, yaml_content, link_ok, expected_checked):
+    charmcraft_yaml = tmp_path / 'charmcraft.yaml'
     charmcraft_yaml.write_text(yaml_content)
     mock_head.return_value.ok = link_ok
     result = evaluate.metadata_links(tmp_path)
-    assert (result.startswith("* [x]")) == expected_checked
+    assert (result.startswith('* [x]')) == expected_checked
 
 
 @pytest.mark.parametrize(
-    "yaml_content,expected_checked",
+    'yaml_content,expected_checked',
     [
         # Success: all relations have 'optional'.
         (
@@ -312,7 +310,7 @@ name: foo
     ],
 )
 def test_relations_includes_optional(tmp_path, yaml_content, expected_checked):
-    charmcraft_yaml = tmp_path / "charmcraft.yaml"
+    charmcraft_yaml = tmp_path / 'charmcraft.yaml'
     charmcraft_yaml.write_text(yaml_content)
     result = evaluate.relations_includes_optional(tmp_path)
-    assert (result.startswith("* [x]")) == expected_checked
+    assert (result.startswith('* [x]')) == expected_checked

--- a/tests/unit/test_update_issue.py
+++ b/tests/unit/test_update_issue.py
@@ -1,0 +1,19 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test the issue comment generation."""
+
+
+def test_dummy():
+    pass

--- a/tests/unit/test_update_issue.py
+++ b/tests/unit/test_update_issue.py
@@ -14,6 +14,195 @@
 
 """Test the issue comment generation."""
 
+from unittest import mock
 
-def test_dummy():
-    pass
+import charmhub_listing_review.update_issue as update_issue
+
+
+@mock.patch('random.choice')
+@mock.patch('subprocess.run')
+@mock.patch('yaml.safe_load')
+@mock.patch('pathlib.Path.open')
+def test_assign_review_multiple_teams(
+    mock_open, mock_yaml_load, mock_subprocess_run, mock_random_choice
+):
+    reviewers_yaml = {
+        'reviewers': {
+            'alice': {'team': 'team1'},
+            'bob': {'team': 'team2'},
+            'carol': {'team': 'team1'},
+        }
+    }
+    mock_yaml_load.return_value = reviewers_yaml
+    mock_open.return_value.__enter__.return_value = mock.Mock()
+    mock_subprocess_run.return_value = mock.Mock()
+    mock_random_choice.return_value = 'bob'
+    reviewer = update_issue.assign_review(42)
+    assert reviewer == 'bob'
+    mock_subprocess_run.assert_called_once_with([
+        'gh',
+        'issue',
+        'edit',
+        '42',
+        '--add-assignee',
+        reviewer,
+    ])
+
+
+@mock.patch('subprocess.run')
+@mock.patch('yaml.safe_load')
+@mock.patch('pathlib.Path.open')
+def test_assign_review_single_team(mock_open, mock_yaml_load, mock_subprocess_run):
+    reviewers_yaml = {
+        'reviewers': {
+            'alice': {'team': 'team1'},
+        }
+    }
+    mock_yaml_load.return_value = reviewers_yaml
+    mock_open.return_value.__enter__.return_value = mock.Mock()
+    mock_subprocess_run.return_value = mock.Mock()
+    reviewer = update_issue.assign_review(99)
+    assert reviewer == 'alice'
+    mock_subprocess_run.assert_called_once_with([
+        'gh',
+        'issue',
+        'edit',
+        '99',
+        '--add-assignee',
+        reviewer,
+    ])
+
+
+@mock.patch('subprocess.run')
+def test_get_details_from_issue(mock_subprocess_run):
+    issue_body = """
+### Charm name
+my-charm
+
+### Demo
+https://demo.example.com
+
+### Project Repository
+https://github.com/canonical/my-charm
+
+### CI Linting
+https://ci.example.com/lint
+
+### CI Release
+https://ci.example.com/release
+
+### CI Integration Tests
+https://ci.example.com/integration
+
+### Documentation Link
+https://docs.example.com
+"""
+    mock_subprocess_run.return_value = mock.Mock(stdout=issue_body)
+    details = update_issue.get_details_from_issue(123)
+    assert details['name'] == 'my-charm'
+    assert details['demo_url'] == 'https://demo.example.com'
+    assert details['project_repo'] == 'https://github.com/canonical/my-charm'
+    assert details['ci_linting'] == 'https://ci.example.com/lint'
+    assert details['ci_release_url'] == 'https://ci.example.com/release'
+    assert details['ci_integration_url'] == 'https://ci.example.com/integration'
+    assert details['documentation_link'] == 'https://docs.example.com'
+    assert (
+        details['contribution_link']
+        == 'https://github.com/canonical/my-charm/blob/main/CONTRIBUTING.md'
+    )
+    assert details['license_link'] == 'https://github.com/canonical/my-charm/blob/main/LICENSE'
+    assert (
+        details['security_link'] == 'https://github.com/canonical/my-charm/blob/main/SECURITY.md'
+    )
+
+
+def test_extract_best_practice_blocks_markdown(tmp_path):
+    md_file = tmp_path / 'test.md'
+    md_file.write_text(
+        """
+Some intro text
+
+```{admonition} Best practice
+:class: hint
+
+This is a markdown best practice block.
+```
+
+Other text
+
+```{admonition} Best practice
+:class: hint
+
+Another best practice block.
+```
+
+Here is some more text.
+```{tip}
+
+This is just a tip, not a best practice.
+```
+
+Summary text.
+"""
+    )
+    blocks = update_issue.extract_best_practice_blocks(md_file)
+    assert 'This is a markdown best practice block.' in blocks[0]
+    assert 'Another best practice block.' in blocks[1]
+
+
+def test_extract_best_practice_blocks_rest(tmp_path):
+    rst_file = tmp_path / 'test.rst'
+    rst_file.write_text(
+        """
+Some intro text
+
+.. admonition:: Best practice
+    :class: hint
+
+    This is a ReST best practice block.
+
+Other text
+
+.. admonition:: Best practice
+    :class: hint
+
+    Another best practice block.
+
+    This one has multiple paragraphs.
+"""
+    )
+    blocks = update_issue.extract_best_practice_blocks(rst_file)
+    assert 'This is a ReST best practice block.' in blocks[0]
+    assert 'Another best practice block.' in blocks[1]
+    assert 'This one has multiple paragraphs.' in blocks[1]
+
+
+def test_find_best_practices(tmp_path):
+    ops_dir = tmp_path / 'ops'
+    charmcraft_dir = tmp_path / 'charmcraft'
+    ops_dir.mkdir()
+    charmcraft_dir.mkdir()
+    (ops_dir / 'file1.md').write_text(
+        """
+```{admonition} Best practice
+Ops best practice.
+```
+"""
+    )
+    (charmcraft_dir / 'file2.rst').write_text(
+        """
+.. admonition:: Best practice
+    :class: hint
+
+    Charmcraft best practice.
+"""
+    )
+    practices = update_issue.find_best_practices(ops_dir, charmcraft_dir)
+    assert any('Ops best practice.' in p for p in practices)
+    assert any('Charmcraft best practice.' in p for p in practices)
+
+
+def test_issue_summary():
+    name = 'my-charm'
+    summary = update_issue.issue_summary(name)
+    assert summary == 'Review `my-charm` for public listing on Charmhub'

--- a/tests/unit/test_update_issue.py
+++ b/tests/unit/test_update_issue.py
@@ -28,25 +28,25 @@ def test_assign_review_multiple_teams(
 ):
     reviewers_yaml = {
         'reviewers': {
-            'alice': {'team': 'team1'},
-            'bob': {'team': 'team2'},
-            'carol': {'team': 'team1'},
+            '@alice': {'team': 'team1'},
+            '@bob': {'team': 'team2'},
+            '@carol': {'team': 'team1'},
         }
     }
     mock_yaml_load.return_value = reviewers_yaml
     mock_open.return_value.__enter__.return_value = mock.Mock()
     mock_subprocess_run.return_value = mock.Mock()
-    mock_random_choice.return_value = 'bob'
+    mock_random_choice.return_value = '@bob'
     reviewer = update_issue.assign_review(42)
-    assert reviewer == 'bob'
+    assert reviewer == '@bob'
     mock_subprocess_run.assert_called_once_with([
         'gh',
         'issue',
         'edit',
         '42',
         '--add-assignee',
-        reviewer,
-    ])
+        'bob',
+    ], check=True)
 
 
 @mock.patch('subprocess.run')
@@ -55,22 +55,22 @@ def test_assign_review_multiple_teams(
 def test_assign_review_single_team(mock_open, mock_yaml_load, mock_subprocess_run):
     reviewers_yaml = {
         'reviewers': {
-            'alice': {'team': 'team1'},
+            '@alice': {'team': 'team1'},
         }
     }
     mock_yaml_load.return_value = reviewers_yaml
     mock_open.return_value.__enter__.return_value = mock.Mock()
     mock_subprocess_run.return_value = mock.Mock()
     reviewer = update_issue.assign_review(99)
-    assert reviewer == 'alice'
+    assert reviewer == '@alice'
     mock_subprocess_run.assert_called_once_with([
         'gh',
         'issue',
         'edit',
         '99',
         '--add-assignee',
-        reviewer,
-    ])
+        'alice',
+    ], check=True)
 
 
 @mock.patch('subprocess.run')
@@ -167,14 +167,11 @@ Other text
     :class: hint
 
     Another best practice block.
-
-    This one has multiple paragraphs.
 """
     )
     blocks = update_issue.extract_best_practice_blocks(rst_file)
     assert 'This is a ReST best practice block.' in blocks[0]
     assert 'Another best practice block.' in blocks[1]
-    assert 'This one has multiple paragraphs.' in blocks[1]
 
 
 def test_find_best_practices(tmp_path):
@@ -185,6 +182,8 @@ def test_find_best_practices(tmp_path):
     (ops_dir / 'file1.md').write_text(
         """
 ```{admonition} Best practice
+:class: hint
+
 Ops best practice.
 ```
 """

--- a/uv.lock
+++ b/uv.lock
@@ -3,9 +3,22 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "certifi"
+version = "2025.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
+]
+
+[[package]]
 name = "charmhub-listing-review"
 version = "1.0.0a1"
 source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+]
 
 [package.dev-dependencies]
 lint = [
@@ -20,6 +33,10 @@ unit = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "pyyaml", specifier = "==6.*" },
+    { name = "requests", specifier = "~=2.32" },
+]
 
 [package.metadata.requires-dev]
 lint = [
@@ -31,6 +48,48 @@ lint = [
 unit = [
     { name = "coverage", extras = ["toml"], specifier = "~=7.0" },
     { name = "pytest", specifier = "~=8.4" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14", size = 122371, upload-time = "2025-08-09T07:57:28.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5e/14c94999e418d9b87682734589404a25854d5f5d0408df68bc15b6ff54bb/charset_normalizer-3.4.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1", size = 205655, upload-time = "2025-08-09T07:56:08.475Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a8/c6ec5d389672521f644505a257f50544c074cf5fc292d5390331cd6fc9c3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884", size = 146223, upload-time = "2025-08-09T07:56:09.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/eb/a2ffb08547f4e1e5415fb69eb7db25932c52a52bed371429648db4d84fb1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018", size = 159366, upload-time = "2025-08-09T07:56:11.326Z" },
+    { url = "https://files.pythonhosted.org/packages/82/10/0fd19f20c624b278dddaf83b8464dcddc2456cb4b02bb902a6da126b87a1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392", size = 157104, upload-time = "2025-08-09T07:56:13.014Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ab/0233c3231af734f5dfcf0844aa9582d5a1466c985bbed6cedab85af9bfe3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f", size = 151830, upload-time = "2025-08-09T07:56:14.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/02/e29e22b4e02839a0e4a06557b1999d0a47db3567e82989b5bb21f3fbbd9f/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154", size = 148854, upload-time = "2025-08-09T07:56:16.051Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6b/e2539a0a4be302b481e8cafb5af8792da8093b486885a1ae4d15d452bcec/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491", size = 160670, upload-time = "2025-08-09T07:56:17.314Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/883ee5676a2ef217a40ce0bffcc3d0dfbf9e64cbcfbdf822c52981c3304b/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93", size = 158501, upload-time = "2025-08-09T07:56:18.641Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/35/6525b21aa0db614cf8b5792d232021dca3df7f90a1944db934efa5d20bb1/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f", size = 153173, upload-time = "2025-08-09T07:56:20.289Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ee/f4704bad8201de513fdc8aac1cabc87e38c5818c93857140e06e772b5892/charset_normalizer-3.4.3-cp312-cp312-win32.whl", hash = "sha256:fb6fecfd65564f208cbf0fba07f107fb661bcd1a7c389edbced3f7a493f70e37", size = 99822, upload-time = "2025-08-09T07:56:21.551Z" },
+    { url = "https://files.pythonhosted.org/packages/39/f5/3b3836ca6064d0992c58c7561c6b6eee1b3892e9665d650c803bd5614522/charset_normalizer-3.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:86df271bf921c2ee3818f0522e9a5b8092ca2ad8b065ece5d7d9d0e9f4849bcc", size = 107543, upload-time = "2025-08-09T07:56:23.115Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ca/2135ac97709b400c7654b4b764daf5c5567c2da45a30cdd20f9eefe2d658/charset_normalizer-3.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:14c2a87c65b351109f6abfc424cab3927b3bdece6f706e4d12faaf3d52ee5efe", size = 205326, upload-time = "2025-08-09T07:56:24.721Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/98a04c3c97dd34e49c7d247083af03645ca3730809a5509443f3c37f7c99/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41d1fc408ff5fdfb910200ec0e74abc40387bccb3252f3f27c0676731df2b2c8", size = 146008, upload-time = "2025-08-09T07:56:26.004Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/4659a4cb3c4ec146bec80c32d8bb16033752574c20b1252ee842a95d1a1e/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1bb60174149316da1c35fa5233681f7c0f9f514509b8e399ab70fea5f17e45c9", size = 159196, upload-time = "2025-08-09T07:56:27.25Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9e/f552f7a00611f168b9a5865a1414179b2c6de8235a4fa40189f6f79a1753/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30d006f98569de3459c2fc1f2acde170b7b2bd265dc1943e87e1a4efe1b67c31", size = 156819, upload-time = "2025-08-09T07:56:28.515Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/95/42aa2156235cbc8fa61208aded06ef46111c4d3f0de233107b3f38631803/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:416175faf02e4b0810f1f38bcb54682878a4af94059a1cd63b8747244420801f", size = 151350, upload-time = "2025-08-09T07:56:29.716Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a9/3865b02c56f300a6f94fc631ef54f0a8a29da74fb45a773dfd3dcd380af7/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aab0f181c486f973bc7262a97f5aca3ee7e1437011ef0c2ec04b5a11d16c927", size = 148644, upload-time = "2025-08-09T07:56:30.984Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d9/cbcf1a2a5c7d7856f11e7ac2d782aec12bdfea60d104e60e0aa1c97849dc/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fdabf8315679312cfa71302f9bd509ded4f2f263fb5b765cf1433b39106c3cc9", size = 160468, upload-time = "2025-08-09T07:56:32.252Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/42/6f45efee8697b89fda4d50580f292b8f7f9306cb2971d4b53f8914e4d890/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5", size = 158187, upload-time = "2025-08-09T07:56:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/70/99/f1c3bdcfaa9c45b3ce96f70b14f070411366fa19549c1d4832c935d8e2c3/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:18343b2d246dc6761a249ba1fb13f9ee9a2bcd95decc767319506056ea4ad4dc", size = 152699, upload-time = "2025-08-09T07:56:34.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/b0081f2f99a4b194bcbb1934ef3b12aa4d9702ced80a37026b7607c72e58/charset_normalizer-3.4.3-cp313-cp313-win32.whl", hash = "sha256:6fb70de56f1859a3f71261cbe41005f56a7842cc348d3aeb26237560bfa5e0ce", size = 99580, upload-time = "2025-08-09T07:56:35.981Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/8f/ae790790c7b64f925e5c953b924aaa42a243fb778fed9e41f147b2a5715a/charset_normalizer-3.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:cf1ebb7d78e1ad8ec2a8c4732c7be2e736f6e5123a4146c5b89c9d1f585f8cef", size = 107366, upload-time = "2025-08-09T07:56:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/91/b5a06ad970ddc7a0e513112d40113e834638f4ca1120eb727a249fb2715e/charset_normalizer-3.4.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3cd35b7e8aedeb9e34c41385fda4f73ba609e561faedfae0a9e75e44ac558a15", size = 204342, upload-time = "2025-08-09T07:56:38.687Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ec/1edc30a377f0a02689342f214455c3f6c2fbedd896a1d2f856c002fc3062/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89bc04de1d83006373429975f8ef9e7932534b8cc9ca582e4db7d20d91816db", size = 145995, upload-time = "2025-08-09T07:56:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e5/5e67ab85e6d22b04641acb5399c8684f4d37caf7558a53859f0283a650e9/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2001a39612b241dae17b4687898843f254f8748b796a2e16f1051a17078d991d", size = 158640, upload-time = "2025-08-09T07:56:41.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e5/38421987f6c697ee3722981289d554957c4be652f963d71c5e46a262e135/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8dcfc373f888e4fb39a7bc57e93e3b845e7f462dacc008d9749568b1c4ece096", size = 156636, upload-time = "2025-08-09T07:56:43.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e4/5a075de8daa3ec0745a9a3b54467e0c2967daaaf2cec04c845f73493e9a1/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b97b8404387b96cdbd30ad660f6407799126d26a39ca65729162fd810a99aa", size = 150939, upload-time = "2025-08-09T07:56:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f7/3611b32318b30974131db62b4043f335861d4d9b49adc6d57c1149cc49d4/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccf600859c183d70eb47e05a44cd80a4ce77394d1ac0f79dbd2dd90a69a3a049", size = 148580, upload-time = "2025-08-09T07:56:46.684Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/61/19b36f4bd67f2793ab6a99b979b4e4f3d8fc754cbdffb805335df4337126/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:53cd68b185d98dde4ad8990e56a58dea83a4162161b1ea9272e5c9182ce415e0", size = 159870, upload-time = "2025-08-09T07:56:47.941Z" },
+    { url = "https://files.pythonhosted.org/packages/06/57/84722eefdd338c04cf3030ada66889298eaedf3e7a30a624201e0cbe424a/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:30a96e1e1f865f78b030d65241c1ee850cdf422d869e9028e2fc1d5e4db73b92", size = 157797, upload-time = "2025-08-09T07:56:49.756Z" },
+    { url = "https://files.pythonhosted.org/packages/72/2a/aff5dd112b2f14bcc3462c312dce5445806bfc8ab3a7328555da95330e4b/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16", size = 152224, upload-time = "2025-08-09T07:56:51.369Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8c/9839225320046ed279c6e839d51f028342eb77c91c89b8ef2549f951f3ec/charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce", size = 100086, upload-time = "2025-08-09T07:56:52.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7a/36fbcf646e41f710ce0a563c1c9a343c6edf9be80786edeb15b6f62e17db/charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c", size = 107400, upload-time = "2025-08-09T07:56:55.172Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
 ]
 
 [[package]]
@@ -116,6 +175,15 @@ wheels = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -165,6 +233,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
 ]
 
 [[package]]
@@ -225,4 +334,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]


### PR DESCRIPTION
This PR adds the core automation of public listing review requests.

The update_issue.py script is run when an issue with the appropriate label is created or labelled, or when comments are added or edited. The script:

* Sets a standard summary for the issue.
* Creates instructions and a checklist for the review, and either posts it as a comment (if one doesn't already exist) or updates the existing comment with the latest state.
* The above comment also includes assigning the issue (to a manager) and asking them to delegate it to someone in their team.
* Figures out who the manager has assigned to the review, by looking for a comment where they have done this (this is more fragile than I would like, but is also easily fixed by editing a comment, and I don't have any better ideas).
* Looks for comments by the reviewer and uses those to also update the state in the updated comment. The reviewer can overrule the automated checks where necessary.

The raw data for the review (the charm repository location and so forth) is read from the issue description.

A follow-up PR will make it possible to use this script via an entry point for checking the status of a charm prior to requesting public listing, so that authors can get an idea of how close they are. The output will need to be in a different format so that it's clear what gets checked automatically and what they need to make their own judgement call on, and probably we can point to more documentation. The details of this system are left for that future PR.

Another follow-up PR will improve the way that we track the "done"/"not done/unknown" status for each item, so that we aren't relying on string-matching "* [ ]" and "* [x]" (note that currently even using `-` rather than `*` will break the match). Ideally, that would be in this PR but it's already as large as I'd like it to be, and it does actually work as-is, and I'd like to have it actually tested out end-to-end.