### PR TITLE
fix: explicitly provide the path to the reviewers file

### DIFF
--- a/.github/workflows/review-request.yaml
+++ b/.github/workflows/review-request.yaml
@@ -34,8 +34,6 @@ jobs:
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            # TODO: This is not the best way to run the script, we should clean this up, but just
-            # getting it working for now.
             uv venv
             uv pip install .
-            uv run update-issue --issue-number "${{ github.event.issue.number }}"
+            uv run update-issue --issue-number "${{ github.event.issue.number }}" --reviewers-file "${{ github.workspace }}/reviewers.yaml"

--- a/tests/unit/test_update_issue.py
+++ b/tests/unit/test_update_issue.py
@@ -14,6 +14,7 @@
 
 """Test the issue comment generation."""
 
+import pathlib
 from unittest import mock
 
 import charmhub_listing_review.update_issue as update_issue
@@ -37,7 +38,7 @@ def test_assign_review_multiple_teams(
     mock_open.return_value.__enter__.return_value = mock.Mock()
     mock_subprocess_run.return_value = mock.Mock()
     mock_random_choice.return_value = '@bob'
-    reviewer = update_issue.assign_review(42)
+    reviewer = update_issue.assign_review(42, pathlib.Path('reviewers.yaml'))
     assert reviewer == '@bob'
     mock_subprocess_run.assert_called_once_with(
         [
@@ -64,7 +65,7 @@ def test_assign_review_single_team(mock_open, mock_yaml_load, mock_subprocess_ru
     mock_yaml_load.return_value = reviewers_yaml
     mock_open.return_value.__enter__.return_value = mock.Mock()
     mock_subprocess_run.return_value = mock.Mock()
-    reviewer = update_issue.assign_review(99)
+    reviewer = update_issue.assign_review(99, pathlib.Path('reviewers.yaml'))
     assert reviewer == '@alice'
     mock_subprocess_run.assert_called_once_with(
         [


### PR DESCRIPTION
Tidy up the use of the reviewers.json file by explicitly providing the path to it when used (most typically by the GitHub actions workflow).

Refs #13