### PR TITLE
fix: Correct Pietro's GitHub username

### DIFF
--- a/reviewers.yaml
+++ b/reviewers.yaml
@@ -10,7 +10,7 @@ reviewers:
     "@sed-i":
         name: "Leon Mintz"
         team: "Observability Core"
-    "@ppasotti":
+    "@pietropasotti":
         name: "Pietro Pasotti"
         team: "Observability Tracing"
     "@simskij":


### PR DESCRIPTION
Either wrong in directory, which is currently down, or I copied it incorrectly.