### PR TITLE
ci: Add basic agent instructions and copilot-collections integration

### DIFF
--- a/.github/.copilot-collections.yaml
+++ b/.github/.copilot-collections.yaml
@@ -1,0 +1,7 @@
+copilot:
+  version: "v0.6.0"
+
+  collections:
+    - charm-tech-core
+    - common-python
+

--- a/.github/workflows/copilot-collections-update.yml
+++ b/.github/workflows/copilot-collections-update.yml
@@ -1,0 +1,13 @@
+name: Update Copilot Instructions  
+on:
+  schedule:  
+    - cron: '28 8 * * 6' # Run every Saturday at 08:28 UTC  
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:  
+  check-update:  
+    # Pinned to main to get the latest logic, but the content comes from the .copilot-collections.yaml file.
+    uses: canonical/copilot-collections/.github/workflows/auto_update_collections.yaml@main
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in this repository.
+
+## Project Overview
+
+This repository manages the public listing review process for charms on [Charmhub](https://charmhub.io). It contains:
+- GitHub issue templates for listing requests
+- Automation tools for evaluating charms against listing requirements
+- Infrastructure for assigning reviewers from charming teams
+
+## Common Commands
+
+```bash
+# Run all checks (lint + unit tests)
+tox
+
+# Run linting and type checks only
+tox -e lint
+
+# Run unit tests with coverage
+tox -e unit
+
+# Run a single test
+tox -e unit -- tests/unit/test_evaluate.py::test_check_charm_name
+
+# Auto-format code
+tox -e format
+
+# Install pre-commit hooks
+pre-commit install
+```
+
+## Code Architecture
+
+### Entry Points (defined in pyproject.toml)
+- `update-issue`: Updates GitHub issues with review checklists (`src/charmhub_listing_review/update_issue.py`)
+- `self-review`: CLI tool for charm authors to self-check before submitting (`src/charmhub_listing_review/self_review.py`)
+
+### Core Modules
+
+**`evaluate.py`** - Automated charm evaluation against listing criteria. Functions clone the charm repo, check `charmcraft.yaml`, validate naming conventions, verify URLs, and return Markdown checklist items (ticked/unticked based on pass/fail).
+
+**`update_issue.py`** - GitHub issue management. Extracts data from listing request issues, generates reviewer checklists (including best practices fetched from canonical/operator), assigns reviewers from `reviewers.yaml`, and posts/updates comments via `gh` CLI.
+
+**`self_review.py`** - Console-friendly version of the evaluation for charm authors to run locally before submitting.
+
+### Reviewer Assignment
+`reviewers.yaml` maps GitHub usernames to charming teams. The `assign_review()` function randomly selects a team, then a reviewer from that team.
+
+## Coding Standards
+
+- Python 3.12+, uses uv for dependency management
+- Ruff for linting/formatting with single quotes
+- Type checking via ty
+- Google-style docstrings
+- Conventional commit messages (feat, fix, docs, ci, chore, etc.)
+- New files need Apache 2.0 copyright header with current year
+
+## Pull Request Guidelines
+
+- PR titles use conventional commit format without scopes
+- Rebase onto `main` before requesting review; use merge commits for subsequent updates
+- Squash merge to `main` using PR title as commit message


### PR DESCRIPTION
Adds copilot-collections integration, with a very minimal set of instructions, so that we have a couple of different repos using that system, to more easily analyse how well it works for us.

Also adds a very basic AGENTS.md file that summarises this repository and how to work with it.