### PR TITLE
ci: quote the 'float' that's the base

### DIFF
--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -75,6 +75,6 @@ body:
     attributes:
       label: "Default Branch"
       description: "If the review should not be against the default branch, specify the correct branch here. Leave blank to use the default branch (typically 'main')."
-      placeholder: 26.04
+      placeholder: "26.04"
     validations:
       required: false


### PR DESCRIPTION
The test template broke, so it was something in the last set of changes. It's probably either the validations key (unlike the rest) or the "26.04" which maybe is causing issues because it parses as a float but placeholders have to be a string. Check that first.