### PR TITLE
docs: refresh SECURITY.md to standard charm-tech template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,15 @@ to determine whether the issue qualifies as a security issue and, if so, in
 which component. We will then figure out a fix, get a CVE
 assigned, and coordinate the release of the fix.
 
+You may also send email to security@ubuntu.com. If you want to encrypt your email,
+follow [Canonical's reporting instructions](https://ubuntu.com/security/disclosure-policy#contact-us).
+
 If you have a deadline for public disclosure, please let us know.
 Our vulnerability management team intends to respond within 3 working
 days of your report. This project aims to resolve all vulnerabilities
 within 90 days.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about what you can expect when you contact us, and what we
+expect from you.


### PR DESCRIPTION
Refreshes `SECURITY.md` to match the standard Charm Tech security-policy template (using `canonical/operator/SECURITY.md` as the reference). The existing file was missing two paragraphs that the rest of the estate now carries:

- **`security@ubuntu.com` contact paragraph** — inserted between the "shimmer GitHub admins" paragraph and the "If you have a deadline…" paragraph.
- **Ubuntu Security disclosure policy closing paragraph** — appended at the end of the file.