### PR TITLE
docs: update request-public-list to make-your-charm-discoverable url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The result of the process is that:
 
 ## Get ready
 
-Read the [documentation](https://documentation.ubuntu.com/ops/latest/howto/request-public-listing/)
+Read the [documentation](https://documentation.ubuntu.com/ops/latest/howto/make-your-charm-discoverable)
 for detailed information about publicly listed charms, the review process, and
 the criteria for public listing.
 


### PR DESCRIPTION
In the `Get ready` section of `README.md`, there is a broken link to https://documentation.ubuntu.com/ops/latest/howto/request-public-listing/. 

This how-to guide existed at some point in https://github.com/canonical/operator/pull/1989 but was renamed to `make-your-charm-discoverable` in the same PR (https://github.com/canonical/operator/pull/1989/changes/a0b4196cb595887a67ca779e7502b4ab9aa55c11). 

This PR updates `README.md` to point to our current how-to guide.