### PR TITLE
test: adopt -Werror in unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,14 @@ update-issue = "charmhub_listing_review.update_issue:main"
 self-review = "charmhub_listing_review.self_review:main"
 
 # Testing tools configuration
+[tool.pytest.ini_options]
+# Promote warnings (deprecations, resource-cleanup leaks, etc.) to errors so
+# they surface in CI rather than going unnoticed. Part of the Charm Tech
+# -Werror rollout (roadmap 26.10/w-error).
+filterwarnings = [
+    "error",
+]
+
 [tool.coverage.run]
 branch = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,8 @@ self-review = "charmhub_listing_review.self_review:main"
 
 # Testing tools configuration
 [tool.pytest.ini_options]
-# Promote warnings (deprecations, resource-cleanup leaks, etc.) to errors so
-# they surface in CI rather than going unnoticed. Part of the Charm Tech
-# -Werror rollout (roadmap 26.10/w-error).
+# Promote warnings (deprecations, resource-cleanup leaks, and so on) to errors so
+# they surface in CI rather than going unnoticed.
 filterwarnings = [
     "error",
 ]


### PR DESCRIPTION
This PR changes warnings in tests to be errors. Everything already passes cleanly, so no other changes are required.