### PR TITLE
feat: support workload-less charm repository naming

### DIFF
--- a/src/charmhub_listing_review/evaluate.py
+++ b/src/charmhub_listing_review/evaluate.py
@@ -394,11 +394,13 @@ def repository_name(repository_url: str, charm_name: str) -> str:
         r'\s+',
         ' ',
         """
-    * [ ] Name the repository using the pattern ``<charm name>-operator`` for a single charm,
-      or ``<base charm name>-operators`` when the repository will hold multiple related charms.
-      For the charm name, see {external+charmcraft:ref}`Charmcraft | Specify a name
-      <specify-a-name>`. See [Create a repository and initialise it]
-      (#create-a-repository-and-initialise-it).
+    * [ ] If your charm operates a workload, name the repository `<charm name>-operator`.
+      For advice about the charm name, see [](#decide-your-charms-name). If your charm doesn't
+      operate a workload (as in the case of integrator charms and configurator charms), the
+      `-operator` suffix isn't needed. For example, `foo-integrator` and `bar-configurator`.
+      Repositories that contain multiple charms or one or more charms and other artefacts
+      (like Rocks) will need to use other naming patterns.
+      See [Create a repository](#create-a-repository).
     """,
     ).strip()
     repo_name = repository_url.rstrip('/').split('/')[-1]
@@ -407,6 +409,10 @@ def repository_name(repository_url: str, charm_name: str) -> str:
     single_pattern = f'{charm_name}-operator'
     multi_pattern = f'{charm_name}-operators'
     if repo_name in (single_pattern, multi_pattern):
+        return description.replace('* [ ]', '* [x]')
+    # Workload-less charms (integrator/configurator) don't need the ``-operator`` suffix —
+    # the repository can be named the same as the charm.
+    if charm_name.endswith(('-integrator', '-configurator')) and repo_name == charm_name:
         return description.replace('* [ ]', '* [x]')
     return description
 

--- a/src/charmhub_listing_review/evaluate.py
+++ b/src/charmhub_listing_review/evaluate.py
@@ -406,13 +406,14 @@ def repository_name(repository_url: str, charm_name: str) -> str:
     repo_name = repository_url.rstrip('/').split('/')[-1]
     if repo_name.endswith('.git'):
         repo_name = repo_name[:-4]
-    single_pattern = f'{charm_name}-operator'
-    multi_pattern = f'{charm_name}-operators'
-    if repo_name in (single_pattern, multi_pattern):
-        return description.replace('* [ ]', '* [x]')
-    # Workload-less charms (integrator/configurator) don't need the ``-operator`` suffix —
-    # the repository can be named the same as the charm.
-    if charm_name.endswith(('-integrator', '-configurator')) and repo_name == charm_name:
+    # Workload-less charms (integrator/configurator) don't need the ``-operator`` suffix,
+    # and the repository should be named the same as the charm — using the ``-operator``
+    # suffix is a hint that the name may not actually reflect a workload-less charm.
+    if charm_name.endswith(('-integrator', '-configurator')):
+        if repo_name == charm_name:
+            return description.replace('* [ ]', '* [x]')
+        return description
+    if repo_name in (f'{charm_name}-operator', f'{charm_name}-operators'):
         return description.replace('* [ ]', '* [x]')
     return description
 

--- a/src/charmhub_listing_review/sphinx_refs.py
+++ b/src/charmhub_listing_review/sphinx_refs.py
@@ -29,6 +29,7 @@ _JUJU_CLI = f'{_JUJU}reference/juju-cli/list-of-juju-cli-commands/'
 
 _OPS = 'https://documentation.ubuntu.com/ops/latest/'
 _OPS_CHARM_CODE = f'{_OPS}howto/write-and-structure-charm-code/'
+_OPS_INITIALISE_PROJECT = f'{_OPS}howto/initialise-your-project/'
 _OPS_MANAGE_CHARMS = f'{_OPS}howto/manage-charms/'
 _OPS_MANAGE_CONFIG = f'{_OPS}howto/manage-configuration/'
 _OPS_MANAGE_LIBS = f'{_OPS}howto/manage-libraries/'
@@ -81,9 +82,10 @@ _SPHINX_TO_MARKDOWN: dict[str, str] = {
     '[Use the Python provided by the base](#define-the-required-dependencies)':
         f'[Use the Python provided by the base]'
         f'({_OPS_CHARM_CODE}#define-the-required-dependencies)',
-    '[Create a repository and initialise it](#create-a-repository-and-initialise-it)':
-        f'[Create a repository and initialise it]'
-        f'({_OPS_CHARM_CODE}#create-a-repository-and-initialise-it)',
+    '[Create a repository](#create-a-repository)':
+        f'[Create a repository]({_OPS_INITIALISE_PROJECT}#create-a-repository)',
+    '[](#decide-your-charms-name)':
+        f'[Decide your charm\'s name]({_OPS_INITIALISE_PROJECT}#decide-your-charms-name)',
     '[Validate your charm with every change](#validate-your-charm-with-every-change)':
         f'[Validate your charm with every change]'
         f'({_OPS_CHARM_CODE}#validate-your-charm-with-every-change)',

--- a/tests/unit/test_evaluate.py
+++ b/tests/unit/test_evaluate.py
@@ -223,7 +223,17 @@ def test_security_doc(mock_url_ok, status, expected):
     'url,charm_name,expected',
     [
         ('https://github.com/canonical/foo-operator', 'foo', True),
+        ('https://github.com/canonical/foo-operators', 'foo', True),
         ('https://github.com/canonical/bar', 'foo', False),
+        ('https://github.com/canonical/data-integrator', 'data-integrator', True),
+        ('https://github.com/canonical/data-integrator-operator', 'data-integrator', True),
+        ('https://github.com/canonical/data-integrator', 'foo', False),
+        (
+            'https://github.com/canonical/request-authentication-configurator',
+            'request-authentication-configurator',
+            True,
+        ),
+        ('https://github.com/canonical/foo', 'foo', False),
     ],
 )
 def test_repository_name(url, charm_name, expected):

--- a/tests/unit/test_evaluate.py
+++ b/tests/unit/test_evaluate.py
@@ -226,7 +226,7 @@ def test_security_doc(mock_url_ok, status, expected):
         ('https://github.com/canonical/foo-operators', 'foo', True),
         ('https://github.com/canonical/bar', 'foo', False),
         ('https://github.com/canonical/data-integrator', 'data-integrator', True),
-        ('https://github.com/canonical/data-integrator-operator', 'data-integrator', True),
+        ('https://github.com/canonical/data-integrator-operator', 'data-integrator', False),
         ('https://github.com/canonical/data-integrator', 'foo', False),
         (
             'https://github.com/canonical/request-authentication-configurator',


### PR DESCRIPTION
This PR updates the automatic evaluation to reflect the changes in https://github.com/canonical/operator/pull/2496.

- Align the repository-name best-practice check - this would happen automatically later anyway, but might as well do it now. The id-based system is also coming, but not implemented in this repo yet.
- Accept a bare `<charm-name>` repository when the charm name ends with `-integrator` or `-configurator`.
- Update the rendered description text and the Sphinx reference mappings for the renamed `#create-a-repository` anchor (now on `howto/initialise-your-project/`) and the new `[](#decide-your-charms-name)` ref.