### PR TITLE
ci: drop redundant "Authenticate GitHub CLI" step in review-request

### DIFF
--- a/.github/workflows/review-request.yaml
+++ b/.github/workflows/review-request.yaml
@@ -27,9 +27,6 @@ jobs:
           sudo snap install just --classic
           uv tool install tox --with tox-uv
 
-      - name: Authenticate GitHub CLI
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-
       - name: Update issue summary and description
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `gh` CLI already picks up `GITHUB_TOKEN` / `GH_TOKEN` from env, and the only `gh`-using step in this workflow already sets `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`. The prior `echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token` step was a no-op — the token was already available to `gh` without it.